### PR TITLE
fixed start paradox

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Jiff Boilerplate App",
   "main": "index.js",
   "scripts": {
-    "start": "gulp watch & http-server",
-    "build":"gulp sass & gulp scripts & gulp angular"
+    "start": "http-server",
+    "build":"gulp sass & gulp scripts & gulp angular",
+    "watch": "gulp watch"
   },
   "keywords": [
     "Jiff",


### PR DESCRIPTION
both tasks in the 'start' script are infinitely running tasks until stopped. This means either one or the other won't run until manually stopped. The solution was to separate the tasks into their own 'watch' and 'start'. These tasks should be run in seperate terminal windows but can be run at the same time